### PR TITLE
Soluciona dos bugs que impedían usar el método principal varias veces

### DIFF
--- a/silabajs.js
+++ b/silabajs.js
@@ -34,7 +34,7 @@
         acentuacion();
         hiato();
         diptongoTriptongo();
-        return silaba;
+        return Object.assign({}, silaba);
     }
 
 
@@ -512,8 +512,6 @@
         }
 
         for (var i = 0; i < silaba.palabra.length; i++) {
-
-            hiato = {};
 
             // Hiato Acentual
             if ('íìúù'.indexOf(silaba.palabra[i]) > -1) {


### PR DESCRIPTION
Usando la librería descubrí que había dos problemas:

- Si se llamaba al método principal `getSilabas` dos veces, la segunda llamada fallaba por [esta asignación](https://github.com/ncofrem/silabajs/blob/master/silabajs.js#L516) 
- Por otro lado, [esta línea](https://github.com/ncofrem/silabajs/blob/master/silabajs.js#L37) sobreescribe el objeto `silaba` en lugar devolver una nueva copia.

Para probar mi solución se puede usar el siguiente código HTML: 

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8">
  <title>Test</title>
  <script src="silabajs.js" type="text/javascript" charset="utf-8"></script>
  <script>
    var a = silabaJS.getSilabas('leer');
    var b = silabaJS.getSilabas('turbohélice');

    console.log(a.palabra);
    console.log(b.palabra);
  </script>
</head>
<body>
</body>
</html>
```
### Resultado antes del fix
```javascript
var a = silabaJS.getSilabas('leer');
var b = silabaJS.getSilabas('turbohélice');

console.log(a.palabra); // devuelve `turbohélice`
console.log(b.palabra); // devuelve `turbohélice`
```

### Resultado tras el fix

```javascript
var a = silabaJS.getSilabas('leer');
var b = silabaJS.getSilabas('turbohélice');

console.log(a.palabra); // devuelve `leer`
console.log(b.palabra); // devuelve `turbohélice`
```